### PR TITLE
Add Cylon.Basestar class

### DIFF
--- a/dist/basestar.js
+++ b/dist/basestar.js
@@ -1,0 +1,40 @@
+/*
+ * basestar
+ * cylonjs.com
+ *
+ * Copyright (c) 2013 The Hybrid Group
+ * Licensed under the Apache 2.0 license.
+*/
+
+
+(function() {
+  'use strict';
+  var namespace;
+
+  namespace = require('node-namespace');
+
+  require('./utils');
+
+  namespace('Cylon', function() {
+    return this.Basestar = (function() {
+      var klass;
+
+      klass = Basestar;
+
+      function Basestar(opts) {
+        this.self = this;
+      }
+
+      Basestar.prototype.proxyMethods = function(methods, target, force) {
+        if (force == null) {
+          force = false;
+        }
+        return proxyFunctionsToObject(methods, target, this.self, force);
+      };
+
+      return Basestar;
+
+    })();
+  });
+
+}).call(this);

--- a/dist/robot.js
+++ b/dist/robot.js
@@ -14,6 +14,8 @@
 
   require('./cylon');
 
+  require('./basestar');
+
   Connection = require("./connection");
 
   Device = require("./device");

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "sinon": "~1.7.3"
   },
   "dependencies": {
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "node-namespace": "~1.0.0"
   }
 }

--- a/src/basestar.coffee
+++ b/src/basestar.coffee
@@ -1,0 +1,25 @@
+###
+ * basestar
+ * cylonjs.com
+ *
+ * Copyright (c) 2013 The Hybrid Group
+ * Licensed under the Apache 2.0 license.
+###
+
+'use strict';
+
+namespace = require 'node-namespace'
+require './utils'
+
+# Basestar is the class used when writing external Cylon adaptors/drivers.
+#
+# It provides some useful methods and behaviour.
+namespace 'Cylon', ->
+  class @Basestar
+    klass = this
+
+    constructor: (opts) ->
+      @self = this
+
+    proxyMethods: (methods, target, force = false) ->
+      proxyFunctionsToObject(methods, target, @self, force)

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -9,6 +9,7 @@
 'use strict';
 
 require('./cylon')
+require('./basestar')
 Connection = require("./connection")
 Device = require("./device")
 Async = require("async")


### PR DESCRIPTION
Can be used as base when writing external modules for Cylon.
