### PR TITLE
Revise proxy to use objects instead of prototypes

### DIFF
--- a/dist/basestar.js
+++ b/dist/basestar.js
@@ -28,11 +28,11 @@
         this.self = this;
       }
 
-      Basestar.prototype.proxyMethods = function(methods, target, klass, force) {
+      Basestar.prototype.proxyMethods = function(methods, target, source, force) {
         if (force == null) {
           force = false;
         }
-        return proxyFunctionsToObject(methods, target, klass, force);
+        return proxyFunctionsToObject(methods, target, source, force);
       };
 
       Basestar.prototype.defineEvent = function(opts) {

--- a/dist/connection.js
+++ b/dist/connection.js
@@ -40,7 +40,7 @@
         this.connection_id = opts.id;
         this.adaptor = this.requireAdaptor(opts.adaptor);
         this.port = new Port(opts.port);
-        proxyFunctionsToObject(this.adaptor.commands(), this.adaptor, Connection);
+        proxyFunctionsToObject(this.adaptor.commands(), this.adaptor, this.self);
       }
 
       Connection.prototype.data = function() {

--- a/dist/device.js
+++ b/dist/device.js
@@ -35,7 +35,7 @@
         this.pin = opts.pin;
         this.connection = this.determineConnection(opts.connection) || this.defaultConnection();
         this.driver = this.requireDriver(opts);
-        proxyFunctionsToObject(this.driver.commands(), this.driver, Device);
+        proxyFunctionsToObject(this.driver.commands(), this.driver, this.self);
       }
 
       Device.prototype.start = function(callback) {

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -27,7 +27,7 @@
       force = false;
     }
     _fn = function(method) {
-      return base.prototype[method] = function() {
+      return base[method] = function() {
         var args;
         args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
         return target[method].apply(target, args);
@@ -36,7 +36,7 @@
     for (_i = 0, _len = methods.length; _i < _len; _i++) {
       method = methods[_i];
       if (!force) {
-        if (typeof base.prototype[method] === 'function') {
+        if (typeof base[method] === 'function') {
           continue;
         }
       }

--- a/src/basestar.coffee
+++ b/src/basestar.coffee
@@ -24,16 +24,16 @@ namespace 'Cylon', ->
     constructor: (opts) ->
       @self = this
 
-    # Public: Proxies calls from all methods in the class to a target class
+    # Public: Proxies calls from all methods in the object to a target object
     #
     # methods - array of methods to proxy
-    # target - class/object to proxy methods to
-    # klass - class to proxy methods from
+    # target - object to proxy methods to
+    # source - object to proxy methods from
     # force - whether or not to overwrite existing method definitions
     #
     # Returns the klass where the methods have been proxied
-    proxyMethods: (methods, target, klass, force = false) ->
-      proxyFunctionsToObject(methods, target, klass, force)
+    proxyMethods: (methods, target, source, force = false) ->
+      proxyFunctionsToObject(methods, target, source, force)
 
     # Public: Defines an event handler that proxies events from a source object
     # to a target object

--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -38,7 +38,7 @@ namespace 'Cylon', ->
       @connection_id = opts.id
       @adaptor = @requireAdaptor(opts.adaptor) # or 'loopback')
       @port = new Port(opts.port)
-      proxyFunctionsToObject @adaptor.commands(), @adaptor, Connection
+      proxyFunctionsToObject @adaptor.commands(), @adaptor, @self
 
     # Public: Exports basic data for the Connection
     #

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -35,7 +35,7 @@ namespace 'Cylon', ->
       @pin = opts.pin
       @connection = @determineConnection(opts.connection) or @defaultConnection()
       @driver = @requireDriver(opts)
-      proxyFunctionsToObject @driver.commands(), @driver, Device
+      proxyFunctionsToObject @driver.commands(), @driver, @self
 
     # Public: Starts the device driver
     #

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -43,9 +43,9 @@ global.after = (delay, action) ->
 global.proxyFunctionsToObject = (methods, target, base = this, force = false) ->
   for method in methods
     unless force
-      continue if typeof base::[method] is 'function'
+      continue if typeof base[method] is 'function'
     do (method) ->
-      base::[method] = (args...) -> target[method](args...)
+      base[method] = (args...) -> target[method](args...)
 
   return base
 

--- a/test/dist/specs/utils.spec.js
+++ b/test/dist/specs/utils.spec.js
@@ -27,14 +27,11 @@
         }
       };
       TestClass = (function() {
-        var klass;
-
-        klass = TestClass;
-
         function TestClass() {
           var methods;
+          this.myself = this;
           methods = ['asString', 'toString', 'returnString'];
-          proxyFunctionsToObject(methods, proxyObject, klass, true);
+          proxyFunctionsToObject(methods, proxyObject, this.myself, true);
         }
 
         return TestClass;

--- a/test/src/specs/utils.spec.coffee
+++ b/test/src/specs/utils.spec.coffee
@@ -18,11 +18,10 @@ describe "Utils", ->
     }
 
     class TestClass
-      klass = this
-
       constructor: ->
+        @myself = this
         methods = ['asString', 'toString', 'returnString']
-        proxyFunctionsToObject(methods, proxyObject, klass, true)
+        proxyFunctionsToObject(methods, proxyObject, @myself, true)
 
     it 'can alias methods', ->
       testclass = new TestClass


### PR DESCRIPTION
Revise proxy to attach functions to objects directly instead of their prototypes.
