### PR TITLE
Allow configuration of API options

### DIFF
--- a/dist/cylon.js
+++ b/dist/cylon.js
@@ -43,11 +43,16 @@
     };
 
     Master = (function() {
-      var api, robots;
+      var api, api_config, robots;
 
       robots = [];
 
       api = null;
+
+      api_config = {
+        host: '127.0.0.1',
+        port: '3000'
+      };
 
       function Master() {
         this.robot = __bind(this.robot, this);
@@ -78,6 +83,12 @@
 
       Master.prototype.robots = function() {
         return robots;
+      };
+
+      Master.prototype.api = function(opts) {
+        api_config.host = opts.host || "127.0.0.1";
+        api_config.port = opts.port || "3000";
+        return api_config;
       };
 
       Master.prototype.findRobot = function(name, callback) {
@@ -167,9 +178,8 @@
       };
 
       Master.prototype.startAPI = function() {
-        return api != null ? api : api = new Api.Server({
-          master: this.self
-        });
+        api_config.master = this.self;
+        return api != null ? api : api = new Api.Server(api_config);
       };
 
       return Master;

--- a/examples/api.coffee
+++ b/examples/api.coffee
@@ -1,0 +1,29 @@
+Cylon = require '..'
+
+Cylon.api host: '0.0.0.0', port: '8080'
+
+bots = [
+  { port: '/dev/rfcomm0', name: 'Thelma' },
+  { port: '/dev/rfcomm1', name: 'Louise' }
+]
+
+SpheroRobot =
+  connection:
+    name: 'Sphero', adaptor: 'sphero'
+
+  device:
+    name: 'sphero', driver: 'sphero'
+
+  work: (me) ->
+    every 1.seconds(), ->
+      Logger.info me.name
+      me.sphero.setRGB Math.floor(Math.random() * 100000)
+      me.sphero.roll 60, Math.floor(Math.random() * 360)
+
+for bot in bots
+  robot = Object.create(SpheroRobot)
+  robot.connection.port = bot.port
+  robot.name = bot.name
+  Cylon.robot robot
+
+Cylon.start()

--- a/src/cylon.coffee
+++ b/src/cylon.coffee
@@ -35,6 +35,7 @@ class Cylon
   class Master
     robots = []
     api = null
+    api_config = { host: '127.0.0.1', port: '3000' }
 
     # Public: Creates a new Master
     #
@@ -75,6 +76,18 @@ class Cylon
     #
     # Returns an array of all Robot instances
     robots: -> robots
+
+    # Public: Configures the API host and port based on passed options
+    #
+    # opts - object containing API options
+    #   host - host address API should serve from
+    #   port - port API should listen for requests on
+    #
+    # Returns the API configuration
+    api: (opts) ->
+      api_config.host = opts.host || "127.0.0.1"
+      api_config.port = opts.port || "3000"
+      api_config
 
     # Public: Finds a particular robot by name
     #
@@ -146,6 +159,7 @@ class Cylon
     #
     # Returns an Api.Server instance
     startAPI: ->
-      api ?= new Api.Server(master: @self)
+      api_config.master = @self
+      api ?= new Api.Server(api_config)
 
 module.exports = Cylon.getInstance()


### PR DESCRIPTION
``` coffeescript
Cylon = require 'cylon'

Cylon.api(host: '0.0.0.0', port: '80')
```
