### PR TITLE
Switch from process.exit() to process.kill()

### DIFF
--- a/dist/cylon.js
+++ b/dist/cylon.js
@@ -70,7 +70,7 @@
         }
         process.on("SIGINT", function() {
           Cylon.getInstance().stop();
-          return process.exit();
+          return process.kill();
         });
       }
 

--- a/src/cylon.coffee
+++ b/src/cylon.coffee
@@ -51,7 +51,7 @@ class Cylon
 
       process.on "SIGINT", ->
         Cylon.getInstance().stop()
-        process.exit()
+        process.kill()
 
     # Public: Creates a new Robot
     #


### PR DESCRIPTION
Moves to use the `process.kill()` method to make sure Cylon shuts down, by sending
a SIGTERM signal to the running process.

This fixes the issues I was having with `cylon-joystick` where despite being told to exit, the node process wouldn't shut down.
