### PR TITLE
Cylon Subcommands

### DIFF
--- a/bin/cylon
+++ b/bin/cylon
@@ -12,6 +12,23 @@ program
   .description("Generates a new adaptor")
   .action(function(name) { require('../src/generators/adaptor')(name) });
 
+// require all cylon-* modules
+require('fs').readdirSync(process.cwd() + '/node_modules/').forEach(function(dir) {
+  if (dir.match(/^cylon-.*/) !== null) {
+    if (typeof require(dir).registerCommands === 'function') {
+      var commands = require(dir).registerCommands();
+      for (name in commands) {
+        var command = commands[name];
+
+        program
+          .command(name)
+          .description(command.description)
+          .action(command.command);
+      }
+    }
+  }
+});
+
 program.parse(process.argv);
 
 // print help if no arguments were provided


### PR DESCRIPTION
This patch allows for subcommands to be loaded from `cylon-*` modules, via a registration function that looks something like this:

``` coffeescript
registerCommands: ->
  {
    leap: {
      description: "Runs LeapMotion thing"
      command: ->
        spawn = require('child_process').spawn
        cmd = require('path').join __dirname, "/../bin/cylon-leap"
        # Spawn child sharing only stderr
        spawn cmd, [], { stdio: ['pipe', 'pipe', process.stderr] }
    }
  }
```

This also means they can define command-line commands without actually having to expose executables in their module.

:cookie: 
