### PR TITLE
Test-driven robotics support

### DIFF
--- a/dist/adaptor.js
+++ b/dist/adaptor.js
@@ -28,10 +28,11 @@
         this.self = this;
         this.name = opts.name;
         this.connection = opts.connection;
+        this.commandList = [];
       }
 
       Adaptor.prototype.commands = function() {
-        return [];
+        return this.commandList;
       };
 
       Adaptor.prototype.connect = function(callback) {

--- a/dist/driver.js
+++ b/dist/driver.js
@@ -29,10 +29,11 @@
         this.name = opts.name;
         this.device = opts.device;
         this.connection = this.device.connection;
+        this.commandList = [];
       }
 
       Driver.prototype.commands = function() {
-        return [];
+        return this.commandList;
       };
 
       Driver.prototype.start = function(callback) {

--- a/dist/robot.js
+++ b/dist/robot.js
@@ -221,8 +221,7 @@
             connection: connection,
             extraParams: opts
           });
-          testAdaptor.proxyTestCommands(realAdaptor);
-          return testAdaptor;
+          return proxyTestStubs(realAdaptor.commands(), testAdaptor);
         } else {
           return realAdaptor;
         }
@@ -258,8 +257,7 @@
             device: device,
             extraParams: opts
           });
-          testDriver.proxyTestCommands(realDriver);
-          return testDriver;
+          return proxyTestStubs(realDriver.commands(), testDriver);
         } else {
           return realDriver;
         }

--- a/dist/test/test-adaptor.js
+++ b/dist/test/test-adaptor.js
@@ -37,32 +37,7 @@
           opts = {};
         }
         TestAdaptor.__super__.constructor.apply(this, arguments);
-        this.commandList = [];
       }
-
-      TestAdaptor.prototype.commands = function() {
-        return this.commandList;
-      };
-
-      TestAdaptor.prototype.proxyTestCommands = function(realAdaptor) {
-        var method, _i, _len, _ref, _results;
-        _ref = realAdaptor.commands();
-        _results = [];
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          method = _ref[_i];
-          this.self[method] = function() {
-            var args;
-            args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
-            return this.self.success();
-          };
-          _results.push(this.commandList.push(method));
-        }
-        return _results;
-      };
-
-      TestAdaptor.prototype.success = function() {
-        return true;
-      };
 
       return TestAdaptor;
 

--- a/dist/test/test-driver.js
+++ b/dist/test/test-driver.js
@@ -37,32 +37,7 @@
           opts = {};
         }
         TestDriver.__super__.constructor.apply(this, arguments);
-        this.commandList = [];
       }
-
-      TestDriver.prototype.commands = function() {
-        return this.commandList;
-      };
-
-      TestDriver.prototype.proxyTestCommands = function(realDriver) {
-        var method, _i, _len, _ref, _results;
-        _ref = realDriver.commands();
-        _results = [];
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          method = _ref[_i];
-          this.self[method] = function() {
-            var args;
-            args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
-            return this.self.success();
-          };
-          _results.push(this.commandList.push(method));
-        }
-        return _results;
-      };
-
-      TestDriver.prototype.success = function() {
-        return true;
-      };
 
       return TestDriver;
 

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -55,6 +55,23 @@
     return base;
   };
 
+  global.proxyTestStubs = function(methods, base) {
+    var method, _i, _len;
+    if (base == null) {
+      base = this;
+    }
+    for (_i = 0, _len = methods.length; _i < _len; _i++) {
+      method = methods[_i];
+      base[method] = function() {
+        var args;
+        args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+        return true;
+      };
+      base.commandList.push(method);
+    }
+    return base;
+  };
+
   Number.prototype.seconds = function() {
     return this * 1000;
   };

--- a/src/adaptor.coffee
+++ b/src/adaptor.coffee
@@ -29,12 +29,13 @@ namespace 'Cylon', ->
       @self = this
       @name = opts.name
       @connection = opts.connection
+      @commandList = []
 
     # Public: Exposes all commands the adaptor will respond to/proxy
     #
     # Returns an array of string method names
     commands: ->
-      []
+      @commandList
 
     # Public: Connects to the adaptor, and emits 'connect' from the @connection
     # when done.
@@ -53,3 +54,8 @@ namespace 'Cylon', ->
     disconnect: ->
       Logger.info "Disconnecting from adaptor '#{@name}'..."
 
+    # # Public: Disconnects from the adaptor
+    # #
+    # # Returns nothing
+    # proxyTestStubs: (testAdaptor) ->
+    #   proxyTestStubs(@self.commands(), testAdaptor)

--- a/src/driver.coffee
+++ b/src/driver.coffee
@@ -30,12 +30,13 @@ namespace 'Cylon', ->
       @name = opts.name
       @device = opts.device
       @connection = @device.connection
+      @commandList = []
 
     # Public: Exposes all commands the driver will respond to/proxy
     #
     # Returns an array of string method names
     commands: ->
-      []
+      @commandList
 
     # Public: Starts up the driver, and emits 'connect' from the @device
     # when done.

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -193,8 +193,7 @@ namespace 'Cylon', ->
           connection: connection,
           extraParams: opts
 
-        testAdaptor.proxyTestCommands(realAdaptor)
-        testAdaptor
+        proxyTestStubs(realAdaptor.commands(), testAdaptor)
       else
         realAdaptor
 
@@ -238,8 +237,7 @@ namespace 'Cylon', ->
           device: device,
           extraParams: opts
 
-        testDriver.proxyTestCommands(realDriver)
-        testDriver
+        proxyTestStubs(realDriver.commands(), testDriver)
       else
         realDriver
 

--- a/src/test/test-adaptor.coffee
+++ b/src/test/test-adaptor.coffee
@@ -18,15 +18,3 @@ namespace 'Cylon.Adaptors', ->
   class @TestAdaptor extends Cylon.Adaptor
     constructor: (opts={}) ->
       super
-      @commandList = []
-
-    commands: ->
-      @commandList
-
-    proxyTestCommands: (realAdaptor) ->
-      for method in realAdaptor.commands()
-        @self[method] = (args...) -> @self.success()
-        @commandList.push method
-
-    success: ->
-      true

--- a/src/test/test-driver.coffee
+++ b/src/test/test-driver.coffee
@@ -18,15 +18,3 @@ namespace 'Cylon.Drivers', ->
   class @TestDriver extends Cylon.Driver
     constructor: (opts={}) ->
       super
-      @commandList = []
-
-    commands: ->
-      @commandList
-
-    proxyTestCommands: (realDriver) ->
-      for method in realDriver.commands()
-        @self[method] = (args...) -> @self.success()
-        @commandList.push method
-
-    success: ->
-      true

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -46,7 +46,7 @@ global.sleep = (ms) ->
   while (Date.now() < start + ms)
     i = 1
 
-# Public: Proxies a list of methods from one oject to another. It will not
+# Public: Proxies a list of methods from one object to another. It will not
 # overwrite existing methods unless told to.
 #
 # methods - array of functions to proxy
@@ -62,6 +62,20 @@ global.proxyFunctionsToObject = (methods, target, base = this, force = false) ->
       continue if typeof base[method] is 'function'
     do (method) ->
       base[method] = (args...) -> target[method](args...)
+
+  base
+
+# Public: Proxies a list of methods for test stubbing.
+#
+# methods - array of functions to proxy
+# base - (optional) object that proxied functions will be declared on. Defaults
+#       to this
+#
+# Returns base
+global.proxyTestStubs = (methods, base = this) ->
+  for method in methods
+    base[method] = (args...) -> true
+    base.commandList.push method
 
   base
 


### PR DESCRIPTION
Add support for auto-stubbing of adaptors and drivers for use when doing test-driven robotics.

Here is an example using Mocha, Sinon, & Chai:

``` javascript
"use strict";
process.env['CYLON_TEST'] = true;

var chai = require("chai");
var sinon = require("sinon");
var sinonChai = require("sinon-chai");
chai.should();
chai.use(sinonChai);

var clock = sinon.useFakeTimers();
var Cylon = require('cylon');
require("./robot.js");

describe("robot", function () {
  var robot = Cylon.findRobot("testor");

  it("should have work", function () {
    return robot.work.should.be.a('function');
  });

  it("should toggle the led after 1 second", function (done) {
    var led = robot.devices['led'];
    var toggle = sinon.stub(led, 'toggle');
    clock.tick((1).second());
    toggle.should.have.been.called;
    done();
  });  
});
```

to test the following robot code:

``` javascript
var Cylon = require("cylon");

var robot = Cylon.robot({
  name: 'testor',
  connection: { name: 'arduino', adaptor: 'firmata', port: '/dev/ttyACM0' },
  device: { name: 'led', driver: 'led', pin: 13 },

  work: function(my) {
    my.led.toggle();

    every((1).second(), function() { my.led.toggle(); });
  }
});

robot.start();
```
