### PR TITLE
Add shortcut for defining adaptor/driver events

### DIFF
--- a/lib/basestar.js
+++ b/lib/basestar.js
@@ -77,9 +77,11 @@ namespace("Cylon", function() {
     //
     // Returns @connector
     Basestar.prototype.defineAdaptorEvent = function(opts) {
+      if (typeof opts === 'string') { opts = { eventName: opts } }
+
       opts['source'] = this.connector;
       opts['target'] = this.connection;
-      if (opts['sendUpdate'] == null) { opts['sendUpdate'] = false; }
+
       return this.defineEvent(opts);
     };
 
@@ -91,9 +93,11 @@ namespace("Cylon", function() {
     //
     // Returns @connection
     Basestar.prototype.defineDriverEvent = function(opts) {
+      if (typeof opts === 'string') { opts = { eventName: opts } }
+
       opts['source'] = this.connection;
       opts['target'] = this.device;
-      if (opts['sendUpdate'] == null) { opts['sendUpdate'] = true; }
+
       return this.defineEvent(opts);
     };
 

--- a/test/specs/basestar.spec.js
+++ b/test/specs/basestar.spec.js
@@ -122,4 +122,68 @@ describe('Basestar', function() {
       assert(!updateSpy.calledWith('testevent', 'data'));
     });
   });
+
+  describe("#defineAdaptorEvent", function() {
+    var basestar;
+
+    before(function() {
+      basestar = new Cylon.Basestar();
+      basestar.connector = new EventEmitter();
+      basestar.connection = new EventEmitter();
+    });
+
+    it("proxies events between the connector and connection", function() {
+      var eventSpy = spy();
+
+      basestar.connection.on('testevent', eventSpy);
+      basestar.defineAdaptorEvent({ eventName: "testevent" });
+
+      basestar.connector.emit("testevent", "data");
+      assert(eventSpy.calledWith('data'));
+    });
+
+    context("when given a string", function() {
+      it("uses it as the eventName", function() {
+        var eventSpy = spy();
+
+        basestar.connection.on('testevent', eventSpy);
+        basestar.defineAdaptorEvent("testevent");
+
+        basestar.connector.emit("testevent", "data");
+        assert(eventSpy.calledWith('data'));
+      });
+    });
+  });
+
+  describe("#defineDriverEvent", function() {
+    var basestar;
+
+    before(function() {
+      basestar = new Cylon.Basestar();
+      basestar.connection = new EventEmitter();
+      basestar.device = new EventEmitter();
+    });
+
+    it("proxies events between the connection and device", function() {
+      var eventSpy = spy();
+
+      basestar.device.on('testevent', eventSpy);
+      basestar.defineDriverEvent({ eventName: "testevent" });
+
+      basestar.connection.emit("testevent", "data");
+      assert(eventSpy.calledWith('data'));
+    });
+
+    context("when given a string", function() {
+      it("uses it as the eventName", function() {
+        var eventSpy = spy();
+
+        basestar.device.on('testevent', eventSpy);
+        basestar.defineDriverEvent("testevent");
+
+        basestar.connection.emit("testevent", "data");
+        assert(eventSpy.calledWith('data'));
+      });
+    });
+  });
 });


### PR DESCRIPTION
Makes it easier to call `defineAdaptorEvent` and `defineDriverEvent`, since it's often done with only one argument in the `opts` object.

``` javascript
this.defineAdaptorEvent({ eventName: "button:press" });
// vs
this.defineAdaptorEvent("button:press");
```
