### PR TITLE
Rename #stop to #halt to avoid potential conflicts

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -102,11 +102,11 @@ namespace("Cylon", function() {
       return this.robot.initAdaptor(opts.adaptor, this.self, opts);
     };
 
-    // Public: Stop the adaptor's connection
+    // Public: Halt the adaptor's connection
     //
     // Returns nothing
-    Connection.prototype.stop = function() {
-      var msg = "Stopping adaptor " + this.name;
+    Connection.prototype.halt = function() {
+      var msg = "Halting adaptor " + this.name;
 
       if (this.port != null) {
         msg += " on port " + this.port.toString();

--- a/lib/cylon.js
+++ b/lib/cylon.js
@@ -56,7 +56,7 @@ var Cylon = (function() {
       }
 
       process.on("SIGINT", function() {
-        Cylon.getInstance().stop();
+        Cylon.getInstance().halt();
         process.kill();
       });
     }
@@ -183,13 +183,13 @@ var Cylon = (function() {
       }
     };
 
-    // Public: Stops the API and the robots
+    // Public: Halts the API and the robots
     //
     // Returns nothing
-    Master.prototype.stop = function() {
+    Master.prototype.halt = function() {
       for (var i = 0; i < this.robots.length; i++) {
         var robot = this.robots[i];
-        robot.stop();
+        robot.halt();
       }
     };
 

--- a/lib/device.js
+++ b/lib/device.js
@@ -35,7 +35,7 @@ namespace("Cylon", function() {
     function Device(opts) {
       if (opts == null) { opts = {}; }
 
-      this.stop = bind(this.stop, this);
+      this.halt = bind(this.halt, this);
       this.start = bind(this.start, this);
 
       this.self = this;
@@ -64,12 +64,12 @@ namespace("Cylon", function() {
       return this.driver.start(callback);
     };
 
-    // Public: Stops the device driver
+    // Public: Halt the device driver
     //
     // Returns result of supplied callback
-    Device.prototype.stop = function() {
-      Logger.info("Stopping device " + this.name);
-      return this.driver.stop();
+    Device.prototype.halt = function() {
+      Logger.info("Halting device " + this.name);
+      return this.driver.halt();
     };
 
     // Public: Exports basic data for the Connection

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -12,8 +12,8 @@ require('./basestar');
 var namespace = require('node-namespace');
 
 // The Driver class is a base class for Driver classes in external Cylon
-// modules to use. It offers basic functions for starting/stopping that
-// descendant classes can.
+// modules to use. It offers basic functions for starting/halting that
+// descendant classes can use.
 namespace("Cylon", function() {
   this.Driver = (function(klass) {
     subclass(Driver, klass);
@@ -56,11 +56,11 @@ namespace("Cylon", function() {
       return true;
     };
 
-    // Public: Stops the driver
+    // Public: Halts the driver
     //
     // Returns nothing
-    Driver.prototype.stop = function() {
-      return Logger.info("Driver " + this.name + " stopped");
+    Driver.prototype.halt = function() {
+      return Logger.info("Driver " + this.name + " halted");
     };
 
     return Driver;

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -58,7 +58,7 @@ namespace("Cylon", function() {
         "requireDriver",
         "registerAdaptor",
         "requireAdaptor",
-        "stop",
+        "halt",
         "startDevices",
         "startConnections",
         "start",
@@ -235,14 +235,14 @@ namespace("Cylon", function() {
       return Async.parallel(starters, callback);
     };
 
-    // Public: Stops the Robot working.
+    // Public: Halts the Robot.
     //
-    // Stops the devices, disconnects the connections.
+    // Halts the devices, disconnects the connections.
     //
     // Returns nothing
-    Robot.prototype.stop = function() {
-      for (var d in this.devices) { this.devices[d].stop(); }
-      for (var c in this.connections) { this.connections[c].stop(); }
+    Robot.prototype.halt = function() {
+      for (var d in this.devices) { this.devices[d].halt(); }
+      for (var c in this.connections) { this.connections[c].halt(); }
     };
 
     // Public: Initialize an adaptor and adds it to @robot.adaptors

--- a/test/specs/connection.spec.js
+++ b/test/specs/connection.spec.js
@@ -102,12 +102,12 @@ describe("Cylon.Connection", function() {
     });
   });
 
-  describe("#stop", function() {
+  describe("#halt", function() {
     before(function() {
       stub(Logger, 'info').returns(true);
       stub(connection, 'disconnect').returns(true);
 
-      connection.stop();
+      connection.halt();
     });
 
     after(function() {
@@ -115,8 +115,8 @@ describe("Cylon.Connection", function() {
       Logger.info.restore();
     });
 
-    it("logs that it's stopping the adaptor", function() {
-      var message = "Stopping adaptor loopback on port /dev/null";
+    it("logs that it's halting the adaptor", function() {
+      var message = "Halting adaptor loopback on port /dev/null";
       expect(Logger.info).to.be.calledWith(message);
     });
 

--- a/test/specs/cylon.spec.js
+++ b/test/specs/cylon.spec.js
@@ -268,21 +268,21 @@ describe("Cylon", function() {
     });
   });
 
-  describe("#stop", function() {
+  describe("#halt", function() {
     before(function() {
       cylon.robots = [];
     });
 
-    it("calls #stop() on all robots", function() {
-      var bot1 = { stop: spy() },
-          bot2 = { stop: spy() };
+    it("calls #halt() on all robots", function() {
+      var bot1 = { halt: spy() },
+          bot2 = { halt: spy() };
 
       cylon.robots = [bot1, bot2];
 
-      cylon.stop();
+      cylon.halt();
 
-      expect(bot1.stop).to.be.called;
-      expect(bot2.stop).to.be.called;
+      expect(bot1.halt).to.be.called;
+      expect(bot2.halt).to.be.called;
     });
   });
 });

--- a/test/specs/device.spec.js
+++ b/test/specs/device.spec.js
@@ -82,25 +82,25 @@ describe("Cylon.Device", function() {
     });
   });
 
-  describe("#stop", function() {
+  describe("#halt", function() {
     before(function() {
-      stub(driver, 'stop').returns(true);
+      stub(driver, 'halt').returns(true);
     });
 
     after(function() {
-      driver.stop.restore();
+      driver.halt.restore();
     });
 
-    it("stops the driver", function() {
-      device.stop();
-      expect(driver.stop).to.be.called;
+    it("halts the driver", function() {
+      device.halt();
+      expect(driver.halt).to.be.called;
     });
 
-    it("logs that it's stopping the device", function() {
-      var message = "Stopping device ping";
+    it("logs that it's halt the device", function() {
+      var message = "Halting device ping";
       stub(Logger, 'info');
 
-      device.stop();
+      device.halt();
 
       expect(Logger.info).to.be.calledWith(message);
       Logger.info.restore();

--- a/test/specs/driver.spec.js
+++ b/test/specs/driver.spec.js
@@ -32,8 +32,8 @@ describe("Driver", function() {
     spy.should.have.been.called;
   });
 
-  it("provides a 'stop' method", function() {
-    expect(driver.stop).to.be.a('function');
+  it("provides a 'halt' method", function() {
+    expect(driver.halt).to.be.a('function');
   });
 
   it("provides a default empty array of commands", function() {

--- a/test/specs/robot.spec.js
+++ b/test/specs/robot.spec.js
@@ -267,7 +267,7 @@ describe("Cylon.Robot", function() {
     });
   });
 
-  describe("#stop", function() {
+  describe("#halt", function() {
     var bot = new Cylon.Robot({
       device: { name: 'ping', driver: 'ping' },
       connection: { name: 'loopback', adaptor: 'loopback' }
@@ -277,20 +277,20 @@ describe("Cylon.Robot", function() {
         connection = bot.connections.loopback;
 
     before(function() {
-      stub(device, 'stop').returns(true);
-      stub(connection, 'stop').returns(true);
+      stub(device, 'halt').returns(true);
+      stub(connection, 'halt').returns(true);
     });
 
     after(function() {
-      device.stop.restore();
-      connection.stop.restore();
+      device.halt.restore();
+      connection.halt.restore();
     });
 
-    it("calls #stop on all devices and connections", function() {
-      bot.stop();
+    it("calls #halt on all devices and connections", function() {
+      bot.halt();
 
-      expect(device.stop).to.be.called;
-      expect(connection.stop).to.be.called;
+      expect(device.halt).to.be.called;
+      expect(connection.halt).to.be.called;
     });
   });
 


### PR DESCRIPTION
Shouldn't impact any modules negatively, and in fact will improve `cylon-sphero` and `cylon-ardrone` by letting them use dedicated `#stop` functions to tell their respective devices to stop moving.
