### PR TITLE
Remove class cruft and namespace from Basestar

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -8,7 +8,8 @@
 
 "use strict";
 
-require('./basestar');
+var Basestar = require('./basestar');
+
 var namespace = require('node-namespace');
 
 // The Adaptor class is a base class for Adaptor classes in external Cylon
@@ -63,5 +64,5 @@ namespace("Cylon", function() {
 
     return Adaptor;
 
-  })(Cylon.Basestar);
+  })(Basestar);
 });

--- a/lib/basestar.js
+++ b/lib/basestar.js
@@ -17,7 +17,9 @@ var EventEmitter = require('events').EventEmitter;
 //
 // It also extends EventEmitter, so child classes are capable of emitting events
 // for other parts of the system to handle.
-var Basestar = function Basestar(opts) {
+var Basestar;
+
+module.exports = Basestar = function Basestar(opts) {
   this.self = this;
 }
 
@@ -98,6 +100,3 @@ Basestar.prototype.defineDriverEvent = function(opts) {
 
   return this.defineEvent(opts);
 };
-
-if (!global.Cylon) { global.Cylon = {}; }
-module.exports = global.Cylon.Basestar = Basestar;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -8,7 +8,8 @@
 
 'use strict';
 
-require('./basestar');
+var Basestar = require('./basestar');
+
 var namespace = require('node-namespace');
 
 // The Driver class is a base class for Driver classes in external Cylon
@@ -65,5 +66,5 @@ namespace("Cylon", function() {
 
     return Driver;
 
-  })(Cylon.Basestar);
+  })(Basestar);
 });

--- a/test/specs/basestar.spec.js
+++ b/test/specs/basestar.spec.js
@@ -1,13 +1,13 @@
 "use strict";
 
-source('basestar');
+var Basestar = source('basestar');
 
 var EventEmitter = require('events').EventEmitter;
 
 describe('Basestar', function() {
   describe('constructor', function() {
     it('assigns @self to the instance of the Basestar class', function() {
-      var instance = new Cylon.Basestar();
+      var instance = new Basestar();
       expect(instance.self).to.be.eql(instance);
     });
   });
@@ -15,36 +15,26 @@ describe('Basestar', function() {
   describe('#proxyMethods', function() {
     var methods = ['asString', 'toString', 'returnString'];
 
-    var ProxyClass = (function() {
-      function ProxyClass() {}
+    var ProxyClass = function ProxyClass() {}
 
-      ProxyClass.prototype.asString = function() {
-        return "[object ProxyClass]";
-      };
+    ProxyClass.prototype.asString = function() {
+      return "[object ProxyClass]";
+    };
 
-      ProxyClass.prototype.toString = function() {
-        return "[object ProxyClass]";
-      };
+    ProxyClass.prototype.toString = function() {
+      return "[object ProxyClass]";
+    };
 
-      ProxyClass.prototype.returnString = function(string) {
-        return string;
-      };
+    ProxyClass.prototype.returnString = function(string) {
+      return string;
+    };
 
-      return ProxyClass;
+    var TestClass = function TestClass() {
+      this.testInstance = new ProxyClass;
+      this.proxyMethods(methods, this.testInstance, this, true);
+    }
 
-    })();
-
-    var TestClass = (function(_super) {
-      subclass(TestClass, _super);
-
-      function TestClass() {
-        this.testInstance = new ProxyClass;
-        this.proxyMethods(methods, this.testInstance, this, true);
-      }
-
-      return TestClass;
-
-    })(Cylon.Basestar);
+    subclass(TestClass, Basestar);
 
     it('can alias methods', function() {
       var testclass = new TestClass;
@@ -66,28 +56,22 @@ describe('Basestar', function() {
   });
 
   describe("#defineEvent", function() {
-    var ProxyClass = (function(klass) {
-      subclass(ProxyClass, klass);
-      function ProxyClass() {}
-      return ProxyClass;
-    })(Cylon.Basestar);
 
-    var EmitterClass = (function(klass) {
-      subclass(EmitterClass, klass);
+    var ProxyClass = function ProxyClass() {};
 
-      function EmitterClass(update) {
-        update || (update = false);
-        this.proxy = new ProxyClass();
-        this.defineEvent({
-          eventName: "testevent",
-          source: this,
-          target: this.proxy,
-          sendUpdate: update
-        });
-      }
+    var EmitterClass = function EmitterClass(update) {
+      update || (update = false);
+      this.proxy = new ProxyClass();
+      this.defineEvent({
+        eventName: "testevent",
+        source: this,
+        target: this.proxy,
+        sendUpdate: update
+      });
+    }
 
-      return EmitterClass;
-    })(Cylon.Basestar);
+    subclass(ProxyClass, Basestar);
+    subclass(EmitterClass, Basestar);
 
     it("proxies events from one class to another", function() {
       var eventSpy = spy(),
@@ -127,7 +111,7 @@ describe('Basestar', function() {
     var basestar;
 
     before(function() {
-      basestar = new Cylon.Basestar();
+      basestar = new Basestar();
       basestar.connector = new EventEmitter();
       basestar.connection = new EventEmitter();
     });
@@ -159,7 +143,7 @@ describe('Basestar', function() {
     var basestar;
 
     before(function() {
-      basestar = new Cylon.Basestar();
+      basestar = new Basestar();
       basestar.connection = new EventEmitter();
       basestar.device = new EventEmitter();
     });


### PR DESCRIPTION
This PR is meant to be a preview of some changes I'd like to see made to Cylon:
- removal of leftover CoffeeScript class cruft
- removal of `node-namespace`

I'm unsure if we actually want to fully remove `node-namespace` at this point, as the layout it gives is at the heart of our current code organization system (at least in cylon-core).

Ultimately, `node-namespace` isn't really doing that much that we can't replicate manually; and adds another dependency that we don't need. I think it's more of a training wheel for Ruby developers who miss the modules/class nesting that's so easy/common in that language.

In modules, I think it's easier to consider dropping `node-namespace`, as they have a single point of entry and Cylon doesn't really care where the actual classes live.
