### PR TITLE
Remove the 'connect' and 'start' events from Adaptors/Drivers

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -44,8 +44,8 @@ Adaptor.prototype.commands = function() {
   return this.commandList;
 };
 
-// Public: Connects to the adaptor, and emits 'connect' from the @connection
-// when done.
+// Public: Connects to the adaptor, and triggers the provided callback when
+// done.
 //
 // callback - function to run when the adaptor is connected
 //
@@ -53,7 +53,6 @@ Adaptor.prototype.commands = function() {
 Adaptor.prototype.connect = function(callback) {
   Logger.info("Connecting to adaptor '" + this.name + "'...");
   callback(null);
-  return this.connection.emit('connect');
 };
 
 // Public: Disconnects from the adaptor

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -45,8 +45,7 @@ Driver.prototype.commands = function() {
   return this.commandList;
 };
 
-// Public: Starts up the driver, and emits 'connect' from the @device
-// when done.
+// Public: Starts up the driver, and triggers the provided callback when done.
 //
 // callback - function to run when the driver is started
 //
@@ -54,7 +53,6 @@ Driver.prototype.commands = function() {
 Driver.prototype.start = function(callback) {
   Logger.info("Driver " + this.name + " started");
   callback(null);
-  this.device.emit('start');
   return true;
 };
 

--- a/test/specs/adaptor.spec.js
+++ b/test/specs/adaptor.spec.js
@@ -47,13 +47,11 @@ describe("Adaptor", function() {
     var callback = spy();
 
     before(function() {
-      stub(connection, 'emit');
       stub(Logger, 'info');
       adaptor.connect(callback);
     });
 
     after(function() {
-      connection.emit.restore();
       Logger.info.restore();
     });
 
@@ -64,10 +62,6 @@ describe("Adaptor", function() {
 
     it("triggers the provided callback", function() {
       expect(callback).to.be.called;
-    });
-
-    it("tells the connection to emit the 'connect' event", function() {
-      expect(connection.emit).to.be.calledWith('connect');
     });
   });
 

--- a/test/specs/driver.spec.js
+++ b/test/specs/driver.spec.js
@@ -74,10 +74,6 @@ describe("Driver", function() {
     it("triggers the provided callback", function() {
       expect(callback).to.be.called;
     });
-
-    it("tells the device to emit the 'start' event", function() {
-      expect(device.emit).to.be.calledWith('start');
-    });
   });
 
   describe("#halt", function() {


### PR DESCRIPTION
These events are being removed, as per the discussion in https://github.com/hybridgroup/cylon/issues/197 and Slack. The appropriate sections should also be removed from the docs site.
