### PR TITLE
Expose commands as array, instead of function

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -32,17 +32,10 @@ module.exports = Adaptor = function Adaptor(opts) {
   this.self = this;
   this.name = opts.name;
   this.connection = opts.connection;
-  this.commandList = [];
+  this.commands = [];
 };
 
 Utils.subclass(Adaptor, Basestar);
-
-// Public: Exposes all commands the adaptor will respond to/proxy
-//
-// Returns an array of string method names
-Adaptor.prototype.commands = function() {
-  return this.commandList;
-};
 
 // Public: Connects to the adaptor, and triggers the provided callback when
 // done.

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -46,7 +46,7 @@ module.exports = Connection = function Connection(opts) {
   this.port = opts.port;
   this.adaptor = this.initAdaptor(opts);
 
-  Utils.proxyFunctionsToObject(this.adaptor.commands(), this.adaptor, this.self);
+  Utils.proxyFunctionsToObject(this.adaptor.commands, this.adaptor, this.self);
 }
 
 Utils.subclass(Connection, EventEmitter);

--- a/lib/device.js
+++ b/lib/device.js
@@ -43,7 +43,7 @@ module.exports = Device = function Device(opts) {
   this.connection = this.determineConnection(opts.connection) || this.defaultConnection();
   this.driver = this.initDriver(opts);
 
-  Utils.proxyFunctionsToObject(this.driver.commands(), this.driver, this.self);
+  Utils.proxyFunctionsToObject(this.driver.commands, this.driver, this.self);
 };
 
 Utils.subclass(Device, EventEmitter);
@@ -83,7 +83,7 @@ Device.prototype.toJSON = function() {
     driver: this.driver.constructor.name || this.driver.name,
     pin: this.pin,
     connection: this.connection.toJSON(),
-    commands: this.driver.commands()
+    commands: this.driver.commands
   };
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -33,17 +33,10 @@ module.exports = Driver = function Driver(opts) {
   this.name = opts.name;
   this.device = opts.device;
   this.connection = this.device.connection;
-  this.commandList = [];
+  this.commands = [];
 };
 
 Utils.subclass(Driver, Basestar);
-
-// Public: Exposes all commands the driver will respond to/proxy
-//
-// Returns an array of string method names
-Driver.prototype.commands = function() {
-  return this.commandList;
-};
 
 // Public: Starts up the driver, and triggers the provided callback when done.
 //

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -298,7 +298,7 @@ Robot.prototype.initAdaptor = function(adaptorName, connection, opts) {
       connection: connection,
       extraParams: opts
     });
-    return Utils.proxyTestStubs(adaptor.commands(), testAdaptor);
+    return Utils.proxyTestStubs(adaptor.commands, testAdaptor);
   } else {
     return adaptor;
   }
@@ -363,7 +363,7 @@ Robot.prototype.initDriver = function(driverName, device, opts) {
       extraParams: opts
     });
 
-    return Utils.proxyTestStubs(driver.commands(), testDriver);
+    return Utils.proxyTestStubs(driver.commands, testDriver);
   } else {
     return driver;
   }

--- a/lib/test/loopback.js
+++ b/lib/test/loopback.js
@@ -15,12 +15,9 @@ var Loopback;
 
 module.exports = Loopback = function Loopback() {
   Loopback.__super__.constructor.apply(this, arguments);
+  this.commands = ['ping'];
 };
 
 Utils.subclass(Loopback, Adaptor);
-
-Loopback.prototype.commands = function() {
-  return ['ping'];
-};
 
 Loopback.adaptor = function(opts) { return new Loopback(opts); };

--- a/lib/test/ping.js
+++ b/lib/test/ping.js
@@ -15,13 +15,10 @@ var Ping;
 
 module.exports = Ping = function Ping() {
   Ping.__super__.constructor.apply(this, arguments);
+  this.commands = ['ping'];
 };
 
 Utils.subclass(Ping, Driver);
-
-Ping.prototype.commands = function() {
-  return ['ping'];
-};
 
 Ping.prototype.ping = function() {
   return "pong";

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -155,7 +155,7 @@ var Utils = module.exports = {
         return true;
       };
 
-      base.commandList.push(method);
+      base.commands.push(method);
     });
 
     return base;

--- a/test/specs/adaptor.spec.js
+++ b/test/specs/adaptor.spec.js
@@ -23,23 +23,8 @@ describe("Adaptor", function() {
       expect(adaptor.connection).to.be.eql(connection);
     });
 
-    it("sets @commandList to an empty array by default", function() {
-      expect(adaptor.commandList).to.be.eql([]);
-    });
-  });
-
-  describe("#commands", function() {
-    var commands = ['list', 'of', 'commands']
-    before(function() {
-      adaptor.commandList = commands;
-    });
-
-    after(function() {
-      adaptor.commandList = [];
-    });
-
-    it("returns the adaptor's @commandList", function() {
-      expect(adaptor.commands()).to.be.eql(commands);
+    it("sets @commands to an empty array by default", function() {
+      expect(adaptor.commands).to.be.eql([]);
     });
   });
 

--- a/test/specs/device.spec.js
+++ b/test/specs/device.spec.js
@@ -134,7 +134,7 @@ describe("Device", function() {
     });
 
     it("contains the device's driver commands", function() {
-      expect(json.commands).to.be.eql(driver.commands());
+      expect(json.commands).to.be.eql(driver.commands);
     });
   });
 

--- a/test/specs/driver.spec.js
+++ b/test/specs/driver.spec.js
@@ -34,23 +34,8 @@ describe("Driver", function() {
       expect(driver.connection).to.be.eql(device.connection);
     });
 
-    it("sets @commandList to an empty array by default", function() {
-      expect(driver.commandList).to.be.eql([]);
-    });
-  });
-
-  describe("#commands", function() {
-    var commands = ['list', 'of', 'commands']
-    before(function() {
-      driver.commandList = commands;
-    });
-
-    after(function() {
-      driver.commandList = [];
-    });
-
-    it("returns the driver's @commandList", function() {
-      expect(driver.commands()).to.be.eql(commands);
+    it("sets @commands to an empty array by default", function() {
+      expect(driver.commands).to.be.eql([]);
     });
   });
 

--- a/test/specs/utils.spec.js
+++ b/test/specs/utils.spec.js
@@ -172,17 +172,17 @@ describe("Utils", function() {
   });
 
   describe("#proxyTestStubs", function() {
-    it("proxies methods to an object's commandList", function() {
+    it("proxies methods to an object's commands", function() {
       var methods = ["hello", "goodbye"],
-          base = { commandList: [] };
+          base = { commands: [] };
 
       utils.proxyTestStubs(methods, base);
-      expect(base.commandList).to.be.eql(methods);
+      expect(base.commands).to.be.eql(methods);
     });
 
     it("returns the object methods have been proxied to", function() {
       var methods = ["hello", "goodbye"],
-          base = { commandList: [] };
+          base = { commands: [] };
 
       expect(utils.proxyTestStubs(methods, base)).to.be.eql(base);
     });


### PR DESCRIPTION
For appropriate classes, `#commands` is now an array, instead of a function that returns the same array.
