### PR TITLE
Remove Utils#bind in preference of built-in function

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -37,7 +37,7 @@ module.exports = Connection = function Connection(opts) {
     opts.id = Math.floor(Math.random() * 10000);
   }
 
-  this.connect = Utils.bind(this.connect, this);
+  this.connect = this.connect.bind(this);
 
   this.self = this;
   this.robot = opts.robot;

--- a/lib/device.js
+++ b/lib/device.js
@@ -28,8 +28,8 @@ var Device = module.exports = function Device(opts) {
     opts = {};
   }
 
-  this.halt = Utils.bind(this.halt, this);
-  this.start = Utils.bind(this.start, this);
+  this.halt = this.halt.bind(this);
+  this.start = this.start.bind(this);
 
   this.robot = opts.robot;
   this.name = opts.name;

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -70,7 +70,7 @@ var Robot = module.exports = function Robot(opts) {
   ];
 
   methods.forEach(function(method) {
-    self[method] = Utils.bind(self[method], self);
+    self[method] = self[method].bind(self);
   });
 
   this.name = opts.name || this.constructor.randomName();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -161,28 +161,6 @@ var Utils = module.exports = {
     return base;
   },
 
-  // Public: Binds an argument to a caller
-  //
-  // fn - function to bind
-  // me - value for 'this' scope inside the function
-  //
-  // Examples
-  //
-  //    var me = { hello: "Hello World" };
-  //    var proxy = { boundMethod: function() { return this.hello; } };
-  //
-  //    proxy.boundMethod = bind(proxy.boundMethod, me);
-  //    proxy.boundMethod();
-  //
-  //    //=> "Hello World"
-  //
-  // Returns a function wrapper
-  bind: function bind(fn, me) {
-    return function() {
-      return fn.apply(me, arguments);
-    };
-  },
-
   // Public: Analogue to Ruby's Hash#fetch method for looking up object
   // properties.
   //

--- a/test/specs/utils.spec.js
+++ b/test/specs/utils.spec.js
@@ -204,25 +204,6 @@ describe("Utils", function() {
     });
   });
 
-  describe("#bind", function() {
-    var me = { hello: "Hello World" },
-        proxy = { boundMethod: function() { return this.hello; } };
-
-    it("binds the 'this' scope for the method", function() {
-      proxy.boundMethod = function() { return this.hello; };
-      proxy.boundMethod = utils.bind(proxy.boundMethod, me);
-
-      expect(proxy.boundMethod()).to.eql("Hello World");
-    });
-
-    it("passes arguments along to bound functions", function() {
-      proxy.boundMethod = function(hello, world) { return [hello, world]; };
-      proxy.boundMethod = utils.bind(proxy.boundMethod, me);
-
-      expect(proxy.boundMethod("Hello", "World")).to.eql(["Hello", "World"]);
-    })
-  });
-
   describe("#fetch", function() {
     var fetch = utils.fetch,
         obj = { property: 'hello world', 'false': false, 'null': null };


### PR DESCRIPTION
We were re-implementing Function.prototype.bind, so let's just use that.

This may necessitate changes in some other modules.

**EDIT:** actually, only looks like the Cylon-Spark lib needs to be changed.
