### PR TITLE
Only require the API/Express when using it.

### DIFF
--- a/lib/cylon.js
+++ b/lib/cylon.js
@@ -10,8 +10,7 @@
 
 var Async = require('async');
 
-var API = require('./api'),
-    Logger = require('./logger'),
+var Logger = require('./logger'),
     Robot = require('./robot'),
     Utils = require('./utils');
 
@@ -59,6 +58,8 @@ Cylon.api = function api(opts) {
   if (opts == null) {
     opts = {};
   }
+
+  var API = require('./api');
 
   this.api_instance = new API(opts);
   this.api_instance.listen();


### PR DESCRIPTION
Fixes an issue with the Tessel, which cannot load Express.
