### PR TITLE
Require a connection if a robot has any devices

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -89,6 +89,13 @@ var Robot = module.exports = function Robot(opts) {
   this.initConnections(opts.connection || opts.connections);
   this.initDevices(opts.device || opts.devices);
 
+  var hasDevices = !!Object.keys(this.devices).length,
+      hasConnections = !!Object.keys(this.connections).length;
+
+  if (hasDevices && !hasConnections) {
+    throw new Error("No connections specified");
+  }
+
   for (var n in opts) {
     var func = opts[n],
         reserved = ['connection', 'connections', 'device', 'devices', 'work'];

--- a/test/specs/robot.spec.js
+++ b/test/specs/robot.spec.js
@@ -71,6 +71,19 @@ describe("Robot", function() {
       expect(robot.extraFunction).to.be.eql(extraFunction);
       expect(robot.extraValue).to.be.eql("Hello World");
     });
+
+    context("if there are devices but no connections", function() {
+      it('throws an error', function() {
+        var fn = function() {
+          return new Robot({
+            name: 'BrokenBot',
+            device: { name: 'ping', driver: 'ping' }
+          });
+        };
+
+        expect(fn).to.throw(Error, "No connections specified");
+      });
+    });
   });
 
   describe("all work and no play", function() {
@@ -229,6 +242,7 @@ describe("Robot", function() {
 
     beforeEach(function() {
       bot = new Robot({
+        connection: [{ name: 'loopback', adaptor: 'loopback' }],
         devices: [
           { name: 'alpha', driver: 'ping' },
           { name: 'bravo', driver: 'ping' }


### PR DESCRIPTION
Per #210, the Robot constructor will now throw an error if no connections are specified on startup. This should hopefully avoid ambiguous errors in the future.
