### PR TITLE
Add direct Adaptor access inside Drivers

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -26,6 +26,7 @@ var Driver = module.exports = function Driver(opts) {
   this.name = opts.name;
   this.device = opts.device;
   this.connection = this.device.connection;
+  this.adaptor = this.connection.adaptor;
   this.interval = extraParams.interval || 10;
 
   this.commands = {};

--- a/test/specs/driver.spec.js
+++ b/test/specs/driver.spec.js
@@ -34,6 +34,10 @@ describe("Driver", function() {
       expect(driver.connection).to.be.eql(device.connection);
     });
 
+    it("sets @connection to the device's connection adaptor", function() {
+      expect(driver.adaptor).to.be.eql(device.connection.adaptor);
+    });
+
     it("sets @commands to an empty object by default", function() {
       expect(driver.commands).to.be.eql({});
     });


### PR DESCRIPTION
Adds direct access of the Connection Adaptor inside Driver subclasses.

Since Drivers should be directly communicating with Adaptors, this facilitates that, rather than roundtripping through the Connection where something else can go wrong. This also allows direct event listening on Adaptors, rather than hoping the correct events were propagated to the Connection.

This PR doesn't break backwards compatibility, but ideally Driver subclasses in modules should be switched to directly talk to the Adaptor where appropriate.
