### PR TITLE
Use Tables in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -191,38 +191,40 @@ Cylon.start();
 Cylon.js has an extensible syntax for connecting to multiple, different hardware
 devices. The following 32 platforms are currently supported:
 
-- [Ardrone](http://ardrone2.parrot.com/) <==> [Adaptor/Drivers](https://github.com/hybridgroup/cylon-ardrone)
-- [Arduino](http://www.arduino.cc/) <==> [Adaptor](https://github.com/hybridgroup/cylon-firmata)
-- [Arduino YUN](http://arduino.cc/en/Main/ArduinoBoardYun?from=Products.ArduinoYUN) <==> [Adaptor](https://github.com/hybridgroup/cylon-firmata)
-- [AT&T M2X](https://m2x.att.com) <==> [Adaptor/Drivers](https://github.com/hybridgroup/cylon-m2x)
-- [Audio]() <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-audio)
-- [Beaglebone Black](http://beagleboard.org/Products/BeagleBone+Black/) <==> [Adaptor](https://github.com/hybridgroup/cylon-beaglebone)
-- [Bluetooth LE](http://en.wikipedia.org/wiki/Bluetooth_low_energy) <==> [Adaptor/Drivers](https://github.com/hybridgroup/cylon-ble)
-- [Crazyflie](http://www.bitcraze.se/) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-crazyflie)
-- [Digispark](http://digistump.com/products/1) <==> [Adaptor](https://github.com/hybridgroup/cylon-digispark)
-- [Intel Edison](http://www.intel.com/content/www/us/en/do-it-yourself/edison.html) <==> [Adaptor](https://github.com/hybridgroup/cylon-intel-iot)
-- [Intel Galileo](http://www.intel.com/content/www/us/en/do-it-yourself/galileo-maker-quark-board.html) <==> [Adaptor](https://github.com/hybridgroup/cylon-intel-iot)
-- [Joystick](http://en.wikipedia.org/wiki/Joystick) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-joystick)
-- [Keyboard](http://en.wikipedia.org/wiki/Computer_keyboard) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-keyboard)
-- [Leap Motion](https://www.leapmotion.com/) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-leapmotion)
-- [MQTT](http://mqtt.org/) <==> [Adaptor/Drivers](https://github.com/hybridgroup/cylon-mqtt)
-- [Nest](http://nest.com/) <==> [Adaptor/Drivers](https://github.com/hybridgroup/cylon-nest)
-- [Neurosky](http://store.neurosky.com/products/mindwave-mobile) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-neurosky)
-- [Ollie](http://gosphero.com/ollie) <==> [Driver](https://github.com/hybridgroup/cylon-ollie)
-- [OpenCV](http://opencv.org/) <==> [Adaptor/Drivers](https://github.com/hybridgroup/cylon-opencv)
-- [Phillips Hue](http://www2.meethue.com/) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-hue)
-- [Pebble](http://www.getpebble.com/) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-pebble)
-- [Pinoccio](https://pinocc.io) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-pinoccio)
-- [PowerUp 3.0](http://www.poweruptoys.com/products/powerup-v3) <==> [Driver](https://github.com/hybridgroup/cylon-powerup)
-- [Rapiro](http://www.rapiro.com/) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-rapiro)
-- [Raspberry Pi](http://www.raspberrypi.org/) <==> [Adaptor](https://github.com/hybridgroup/cylon-raspi)
-- [Salesforce](http://www.force.com/) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-force)
-- [Skynet](http://skynet.im/) <==> [Adaptor](https://github.com/hybridgroup/cylon-skynet)
-- [Spark](http://www.spark.io/) <==> [Adaptor](https://github.com/hybridgroup/cylon-spark)
-- [Speech]() <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-speech)
-- [Sphero](http://www.gosphero.com/) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-sphero)
-- [Tessel](https://tessel.io/) <==> [Adaptor/Driver](https://github.com/hybridgroup/cylon-tessel)
-- [WICED Sense](http://www.broadcom.com/products/wiced/sense/) <==> [Driver](https://github.com/hybridgroup/cylon-wiced-sense)
+| Platform                                                                                              | Support                                                             |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [Ardrone](http://ardrone2.parrot.com/)                                                                | [cylon-ardrone](https://github.com/hybridgroup/cylon-ardrone)
+| [Arduino](http://www.arduino.cc/)                                                                     | [cylon-firmata](https://github.com/hybridgroup/cylon-firmata)
+| [Arduino YUN](http://arduino.cc/en/Main/ArduinoBoardYun?from=Products.ArduinoYUN)                     | [cylon-firmata](https://github.com/hybridgroup/cylon-firmata)
+| [AT&T M2X](https://m2x.att.com)                                                                       | [cylon-m2x](https://github.com/hybridgroup/cylon-m2x)
+| [Audio]()                                                                                             | [cylon-audio](https://github.com/hybridgroup/cylon-audio)
+| [Beaglebone Black](http://beagleboard.org/Products/BeagleBone+Black/)                                 | [cylon-beaglebone](https://github.com/hybridgroup/cylon-beaglebone)
+| [Bluetooth LE](http://en.wikipedia.org/wiki/Bluetooth_low_energy)                                     | [cylon-ble](https://github.com/hybridgroup/cylon-ble)
+| [Crazyflie](http://www.bitcraze.se/)                                                                  | [cylon-crazyflie](https://github.com/hybridgroup/cylon-crazyflie)
+| [Digispark](http://digistump.com/products/1)                                                          | [cylon-digispark](https://github.com/hybridgroup/cylon-digispark)
+| [Intel Edison](http://www.intel.com/content/www/us/en/do-it-yourself/edison.html)                     | [cylon-intel-iot](https://github.com/hybridgroup/cylon-intel-iot)
+| [Intel Galileo](http://www.intel.com/content/www/us/en/do-it-yourself/galileo-maker-quark-board.html) | [cylon-intel-iot](https://github.com/hybridgroup/cylon-intel-iot)
+| [Joystick](http://en.wikipedia.org/wiki/Joystick)                                                     | [cylon-joystick](https://github.com/hybridgroup/cylon-joystick)
+| [Keyboard](http://en.wikipedia.org/wiki/Computer_keyboard)                                            | [cylon-keyboard](https://github.com/hybridgroup/cylon-keyboard)
+| [Leap Motion](https://www.leapmotion.com/)                                                            | [cylon-leapmotion](https://github.com/hybridgroup/cylon-leapmotion)
+| [MQTT](http://mqtt.org/)                                                                              | [cylon-mqtt](https://github.com/hybridgroup/cylon-mqtt)
+| [Nest](http://nest.com/)                                                                              | [cylon-nest](https://github.com/hybridgroup/cylon-nest)
+| [Neurosky](http://store.neurosky.com/products/mindwave-mobile)                                        | [cylon-neurosky](https://github.com/hybridgroup/cylon-neurosky)
+| [Ollie](http://gosphero.com/ollie)                                                                    | [cylon-ollie](https://github.com/hybridgroup/cylon-ollie)
+| [OpenCV](http://opencv.org/)                                                                          | [cylon-opencv](https://github.com/hybridgroup/cylon-opencv)
+| [Phillips Hue](http://www2.meethue.com/)                                                              | [cylon-hue](https://github.com/hybridgroup/cylon-hue)
+| [Pebble](http://www.getpebble.com/)                                                                   | [cylon-pebble](https://github.com/hybridgroup/cylon-pebble)
+| [Pinoccio](https://pinocc.io)                                                                         | [cylon-pinoccio](https://github.com/hybridgroup/cylon-pinoccio)
+| [PowerUp 3.0](http://www.poweruptoys.com/products/powerup-v3)                                         | [cylon-powerup](https://github.com/hybridgroup/cylon-powerup)
+| [Rapiro](http://www.rapiro.com/)                                                                      | [cylon-rapiro](https://github.com/hybridgroup/cylon-rapiro)
+| [Raspberry Pi](http://www.raspberrypi.org/)                                                           | [cylon-raspi](https://github.com/hybridgroup/cylon-raspi)
+| [Salesforce](http://www.force.com/)                                                                   | [cylon-force](https://github.com/hybridgroup/cylon-force)
+| [Skynet](http://skynet.im/)                                                                           | [cylon-skynet](https://github.com/hybridgroup/cylon-skynet)
+| [Spark](http://www.spark.io/)                                                                         | [cylon-spark](https://github.com/hybridgroup/cylon-spark)
+| [Speech]()                                                                                            | [cylon-speech](https://github.com/hybridgroup/cylon-speech)
+| [Sphero](http://www.gosphero.com/)                                                                    | [cylon-sphero](https://github.com/hybridgroup/cylon-sphero)
+| [Tessel](https://tessel.io/)                                                                          | [cylon-tessel](https://github.com/hybridgroup/cylon-tessel)
+| [WICED Sense](http://www.broadcom.com/products/wiced/sense/)                                          | [cylon-wiced-sense](https://github.com/hybridgroup/cylon-wiced-sense)
 
 Our implementation of GPIO (General Purpose Input/Output) allows for a shared
 set of drivers supporting a number of devices:
@@ -309,76 +311,42 @@ on the [https://github.com/hybridgroup/cylon-site](https://github.com/hybridgrou
 
 ## Release History
 
-Version 0.21.1 - Add back debug logging for starting/connecting devices/connections
-
-Version 0.21.0 - Remove Connection/Device objects, update Robot
-                 connection/device syntax, fluent syntax updates
-
-Version 0.20.2 - Correct API issues, possible issue with test setups
-
-Version 0.20.1 - Revert accidental scrict handling of param in driver initializer
-
-Version 0.20.0 - Browser support, new module loading, log level support, misc.
-                 development changes
-
-Version 0.19.1 - Correct issue with dynamic method proxying
-
-Version 0.19.0 - Fluent syntax, improved start/halt, various other updates
-
-Version 0.18.0 - Updates Robot and Driver commands structure
-
-Version 0.17.0 - Updates to API to match CPPP-IO spec
-
-Version 0.16.0 - New IO Utils, removal of Utils#bind, add Adaptor#_noop method.
-
-Version 0.15.1 - Fixed issue with the API on Tessel
-
-Version 0.15.0 - Better halting, cleaner startup, removed 'connect' and 'start'
-                 events, and misc other cleanups/refactors.
-
-Version 0.14.0 - Removal of node-namespace and misc. cleanup
-
-Version 0.13.3 - Fixes bug with disconnect functions not being called.
-
-Version 0.13.2 - Use pure Express, adds server-sent-events, upd API.
-
-Version 0.13.1 - Add API authentication and HTTPS support
-
-Version 0.13.0 - Set minimum Node version to 0.10.20, add utils to global namespace and improve initialization routines
-
-Version 0.12.0 - Extraction of CLI tooling
-
-Version 0.11.2 - bugfixes
-
-Version 0.11.0 - Refactor into pure JavaScript
-
-Version 0.10.4 - Add JS helper functions
-
-Version 0.10.3 - Fix dependency issue
-
-Version 0.10.2 - Create connections convenience vars, refactor config loading
-
-Version 0.10.1 - Updates required for test driven robotics, update Robeaux version, bugfixes
-
-Version 0.10.0 - Use Robeaux UX, add CLI commands for helping connect to devices, bugfixes
-
-Version 0.9.0 - Add AngularJS web interface to API, extensible commands for CLI
-
-Version 0.8.0 - Refactored Adaptor and Driver into proper base classes for easier authoring of new modules
-
-Version 0.7.0 - cylon command for generating new adaptors, support code for better GPIO support, literate examples
-
-Version 0.6.0 - API exposes robot commands, fixes issues in driver/adaptor init
-
-Version 0.5.0 - Improve API, add GPIO support for reuse in adaptors 
-
-Version 0.4.0 - Refactor proxy in Cylon.Basestar, improve API
-
-Version 0.3.0 - Improved Cylon.Basestar, and added API
-
-Version 0.2.0 - Cylon.Basestar to help develop external adaptors/drivers
-
-Version 0.1.0 - Initial release for ongoing development
+| Version | Notes |
+| ------- | ----- |
+| 0.21.1  | Add back debug logging for starting/connecting devices/connections
+| 0.21.0  | Remove Connection/Device objects, update Robot connection/device syntax, fluent syntax updates
+| 0.20.2  | Correct API issues, possible issue with test setups
+| 0.20.1  | Revert accidental scrict handling of param in driver initializer
+| 0.20.0  | Browser support, new module loading, log level support, misc. development changes
+| 0.19.1  | Correct issue with dynamic method proxying
+| 0.19.0  | Fluent syntax, improved start/halt, various other updates
+| 0.18.0  | Updates Robot and Driver commands structure
+| 0.17.0  | Updates to API to match CPPP-IO spec
+| 0.16.0  | New IO Utils, removal of Utils#bind, add Adaptor#_noop method.
+| 0.15.1  | Fixed issue with the API on Tessel
+| 0.15.0  | Better halting, cleaner startup, removed 'connect' and 'start' events, and misc other cleanups/refactors.
+| 0.14.0  | Removal of node-namespace and misc. cleanup
+| 0.13.3  | Fixes bug with disconnect functions not being called.
+| 0.13.2  | Use pure Express, adds server-sent-events, upd API.
+| 0.13.1  | Add API authentication and HTTPS support
+| 0.13.0  | Set minimum Node version to 0.10.20, add utils to global namespace and improve initialization routines
+| 0.12.0  | Extraction of CLI tooling
+| 0.11.2  | bugfixes
+| 0.11.0  | Refactor into pure JavaScript
+| 0.10.4  | Add JS helper functions
+| 0.10.3  | Fix dependency issue
+| 0.10.2  | Create connections convenience vars, refactor config loading
+| 0.10.1  | Updates required for test driven robotics, update Robeaux version, bugfixes
+| 0.10.0  | Use Robeaux UX, add CLI commands for helping connect to devices, bugfixes
+| 0.9.0   | Add AngularJS web interface to API, extensible commands for CLI
+| 0.8.0   | Refactored Adaptor and Driver into proper base classes for easier authoring of new modules
+| 0.7.0   | cylon command for generating new adaptors, support code for better GPIO support, literate examples
+| 0.6.0   | API exposes robot commands, fixes issues in driver/adaptor init
+| 0.5.0   | Improve API, add GPIO support for reuse in adaptors
+| 0.4.0   | Refactor proxy in Cylon.Basestar, improve API
+| 0.3.0   | Improved Cylon.Basestar, and added API
+| 0.2.0   | Cylon.Basestar to help develop external adaptors/drivers
+| 0.1.0   | Initial release for ongoing development
 
 ## License
 


### PR DESCRIPTION
The eternal oddball, it would appear that GitHub Flavored Markdown supports tables.

[Platforms section](https://github.com/hybridgroup/cylon/blob/edc98c009da2cea4f6722d90fb554ef236434935/README.markdown#hardware-support)

[Version History section](https://github.com/hybridgroup/cylon/blob/edc98c009da2cea4f6722d90fb554ef236434935/README.markdown#release-history)

May or may not be a better solution, I at least find it easier to read.
