### PR TITLE
Add support for nested device details inside connection

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -132,6 +132,7 @@ Robot.prototype.connection = function(name, conn) {
   if (this.connections[conn.name]) {
     var original = conn.name,
         str;
+
     conn.name = Utils.makeUnique(original, Object.keys(this.connections));
 
     str = "Connection names must be unique.";
@@ -174,10 +175,30 @@ Robot.prototype.initConnections = function(opts) {
       str += "It will be removed in 1.0.0.";
 
       Logger.warn(str);
+
+      _.forEach(opts.connections, function(conn, key) {
+        var name = _.isString(key) ? key : conn.name;
+        this.connection(name, conn);
+      }, this);
+
+      return this.connections;
     }
 
-    _.forEach(opts.connections, function(conn, key) {
+    _.forIn(opts.connections, function(conn, key) {
       var name = _.isString(key) ? key : conn.name;
+
+      if (conn.devices) {
+        _.forIn(conn.devices, function(device, deviceName) {
+          opts.devices = opts.devices || {};
+
+          device.connection = name;
+
+          opts.devices[deviceName] = device;
+        });
+
+        delete conn.devices;
+      }
+
       this.connection(name, conn);
     }, this);
   }
@@ -251,9 +272,16 @@ Robot.prototype.initDevices = function(opts) {
       str += "It will be removed in 1.0.0.";
 
       Logger.warn(str);
+
+      _.forEach(opts.devices, function(device, key) {
+        var name = _.isString(key) ? key : device.name;
+        this.device(name, device);
+      }, this);
+
+      return this.devices;
     }
 
-    _.forEach(opts.devices, function(device, key) {
+    _.forIn(opts.devices, function(device, key) {
       var name = _.isString(key) ? key : device.name;
       this.device(name, device);
     }, this);

--- a/spec/lib/robot.spec.js
+++ b/spec/lib/robot.spec.js
@@ -310,6 +310,35 @@ describe("Robot", function() {
         bot.initConnections({ connections: connections });
         expect(bot.connections.loopback).to.be.instanceOf(Adaptor);
       });
+
+      context("when the object contains device details", function() {
+        var opts;
+
+        beforeEach(function() {
+          opts = {
+            connections: {
+              loopback: {
+                adaptor: "loopback",
+                devices: {
+                  ping: { driver: "ping", pin: 1 }
+                }
+              }
+            }
+          };
+
+          bot.initConnections(opts);
+        });
+
+        it("adds the devices to opts.devices", function() {
+          expect(opts.devices).to.be.eql({
+            ping: { driver: "ping", pin: 1, connection: "loopback" }
+          });
+        });
+
+        it("removes the device details from optsconnections", function() {
+          expect(opts.connections.devices).to.be.eql(undefined);
+        });
+      });
     });
 
     context("when passed an array of connection objects", function() {


### PR DESCRIPTION
e.g.

```javascript
var Cylon = require("./");

Cylon.robot({
  connections: {
    loopback: {
      adaptor: "loopback",
      devices: {
        ping: { driver: "ping", pin: 1 }
      }
    }
  },

  work: function(my) {
    every((2).seconds(), function() {
      console.log(my.ping.ping());
    });
  }
}).start();
```

In the event of a name collision between the `devices` hash and a nested device, the nested device will 'win'.

Additionally, fixed a potential future bug in device/connection initialization if someone created a device/conn named `length`. Not sure why that would happen, but better safe than sorry.e.g.

```javascript
var Cylon = require("./");

Cylon.robot({
  connections: {
    loopback: {
      adaptor: "loopback",
      devices: {
        ping: { driver: "ping", pin: 1 }
      }
    }
  },

  work: function(my) {
    every((2).seconds(), function() {
      console.log(my.ping.ping());
    });
  }
}).start();
```

In the event of a name collision between the `devices` hash and a nested device, the nested device will 'win'.

Additionally, fixed a potential future bug in device/connection initialization if someone created a device/conn named `length`. Not sure why that would happen, but better safe than sorry.