### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+/examples/
+/spec/


### PR DESCRIPTION
This file acts like a `.gitignore`, but for NPM packages. Will avoid bundling along things we don't necessarily want to install alongside the lib directory.

On my system, this decreases install size of Cylon by over `100kb`, from `301kb` to `189kb`.

Then again, maybe we want to include examples for users to find if they dig into `node_modules/cylon`?

It's probably best that we drop the tests for the published modules, though.