### PR TITLE
ignore WebStorm generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 npm-debug.log
 /coverage/
+.idea/


### PR DESCRIPTION
By default without this change in `.gitignore` the following types of automatically generated files will clutter the repository when WebStore is used for development.
![screen shot 2015-02-21 at 9 03 57 am](https://cloud.githubusercontent.com/assets/108018/6315024/a403d382-b9a8-11e4-9fd5-2ba218022c55.png)
