### PR TITLE
Remove deprecated Connection / Device syntaxes

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -157,39 +157,26 @@ Robot.prototype.initRobot = function(opts) {
 Robot.prototype.initConnections = function(opts) {
   this.log("info", "Initializing connections.");
 
-  if (opts.connection == null && opts.connections == null) {
+  if (opts.connections == null) {
     return this.connections;
   }
 
-  if (opts.connection) {
-    this.deprecationWarning("connection");
-    this.connection(opts.connection.name, opts.connection);
-    return this.connections;
-  }
+  _.each(opts.connections, function(conn, key) {
+    var name = _.isString(key) ? key : conn.name;
 
-  if (_.isObjectLoose(opts.connections)) {
-    if (_.isArray(opts.connections)) {
-      this.performArraySetup(opts.connections, "connection", "connections");
-      return this.connections;
+    if (conn.devices) {
+      opts.devices = opts.devices || {};
+
+      _.each(conn.devices, function(device, d) {
+        device.connection = name;
+        opts.devices[d] = device;
+      });
+
+      delete conn.devices;
     }
 
-    _.each(opts.connections, function(conn, key) {
-      var name = _.isString(key) ? key : conn.name;
-
-      if (conn.devices) {
-        opts.devices = opts.devices || {};
-
-        _.each(conn.devices, function(device, d) {
-          device.connection = name;
-          opts.devices[d] = device;
-        });
-
-        delete conn.devices;
-      }
-
-      this.connection(name, conn);
-    }, this);
-  }
+    this.connection(name, conn);
+  }, this);
 
   return this.connections;
 };
@@ -237,7 +224,7 @@ Robot.prototype.device = function(name, device) {
 Robot.prototype.initDevices = function(opts) {
   this.log("info", "Initializing devices.");
 
-  if (opts.device == null && opts.devices == null) {
+  if (opts.devices == null) {
     return this.devices;
   }
 
@@ -246,23 +233,10 @@ Robot.prototype.initDevices = function(opts) {
     throw new Error("No connections specified");
   }
 
-  if (opts.device) {
-    this.deprecationWarning("device");
-    this.device(opts.device.name, opts.device);
-    return this.devices;
-  }
-
-  if (_.isObjectLoose(opts.devices)) {
-    if (_.isArray(opts.devices)) {
-      this.performArraySetup(opts.devices, "device", "devices");
-      return this.devices;
-    }
-
-    _.each(opts.devices, function(device, key) {
-      var name = _.isString(key) ? key : device.name;
-      this.device(name, device);
-    }, this);
-  }
+  _.each(opts.devices, function(device, key) {
+    var name = _.isString(key) ? key : device.name;
+    this.device(name, device);
+  }, this);
 
   return this.devices;
 };
@@ -423,29 +397,4 @@ Robot.prototype.log = function(level) {
   var args = Array.prototype.slice.call(arguments, 1);
   args.unshift("[" + this.name + "] -");
   Logger[level].apply(null, args);
-};
-
-Robot.prototype.performArraySetup = function(things, typeOfThing, arrayName) {
-  var str = "Specifying ";
-  str += arrayName;
-  str += " as an array is deprecated. ";
-  str += "It will be removed in 1.0.0.";
-
-  this.log("warn", str);
-
-  things.forEach(function(t, key) {
-    var name = _.isString(key) === "string" ? key : t.name;
-    this[typeOfThing](name, t);
-  }, this);
-};
-
-Robot.prototype.deprecationWarning = function(kind) {
-  var msg = "Specifying a single ";
-  msg += kind;
-  msg += " with the '";
-  msg += kind;
-  msg += "' key ";
-  msg += "is deprecated. It will be removed in 1.0.0.";
-
-  this.log("warn", msg);
 };

--- a/spec/lib/robot.spec.js
+++ b/spec/lib/robot.spec.js
@@ -294,14 +294,6 @@ describe("Robot", function() {
       });
     });
 
-    context("when passed a connection object", function() {
-      it("instantiates a new connection with the provided object", function() {
-        var connection = { name: "loopback", adaptor: "loopback" };
-        bot.initConnections({ connection: connection });
-        expect(bot.connections["loopback"]).to.be.instanceOf(Adaptor);
-      });
-    });
-
     context("when passed an object containing connection details", function() {
       it("creates new connections with each of the ones provided", function() {
         var connections = {
@@ -339,28 +331,6 @@ describe("Robot", function() {
         it("removes the device details from optsconnections", function() {
           expect(opts.connections.devices).to.be.eql(undefined);
         });
-      });
-    });
-
-    context("when passed an array of connection objects", function() {
-      it("creates new connections with each of the ones provided", function() {
-        var connections = [{ name: "loopback", adaptor: "loopback" }];
-        bot.initConnections({ connections: connections });
-        expect(bot.connections["loopback"]).to.be.instanceOf(Adaptor);
-      });
-
-      it("avoids name collisions", function() {
-        var opts = {
-          connections: [
-            { name: "loopback", adaptor: "loopback" },
-            { name: "loopback", adaptor: "loopback" }
-          ]
-        };
-
-        bot.initConnections(opts);
-
-        var keys = Object.keys(bot.connections);
-        expect(keys).to.be.eql(["loopback", "loopback-1"]);
       });
     });
   });
@@ -409,14 +379,6 @@ describe("Robot", function() {
       });
     });
 
-    context("when passed a device object", function() {
-      it("instantiates a new driver with the provided object", function() {
-        var device = { name: "ping", driver: "ping" };
-        bot.initDevices({ device: device });
-        expect(bot.devices["ping"]).to.be.instanceOf(Driver);
-      });
-    });
-
     context("when passed an object containing device details", function() {
       it("creates new devices with each of the ones provided", function() {
         var devices = {
@@ -425,27 +387,6 @@ describe("Robot", function() {
 
         bot.initDevices({ devices: devices });
         expect(bot.devices.ping).to.be.instanceOf(Driver);
-      });
-    });
-
-    context("when passed an array of device objects", function() {
-      it("instantiates new drivers with provided objects", function() {
-        var devices = [{ name: "ping", driver: "ping" }];
-        bot.initDevices({ devices: devices});
-
-        expect(bot.devices["ping"]).to.be.instanceOf(Driver);
-      });
-
-      it("avoids name collisions collisions", function() {
-        bot.initDevices({
-          devices: [
-            { name: "ping", driver: "ping" },
-            { name: "ping", driver: "ping" }
-          ]
-        });
-
-        var keys = Object.keys(bot.devices);
-        expect(keys).to.be.eql(["ping", "ping-1"]);
       });
     });
   });


### PR DESCRIPTION
Removes deprecation warnings + support for single-object + array syntaxes.

The array syntax will likely continue to work due to the `_.each` abstraction, but since we don't use it anywhere, the requisite specs have been removed.