### PR TITLE
Add a basic-ish debounce implementation, exported as a helper

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -222,6 +222,8 @@ var Utils = module.exports = {
     }
   },
 
+  debounce: _.debounce,
+
   // Public: Adds necessary utils to global namespace, along with base class
   // extensions.
   //

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -1,6 +1,7 @@
 // A collection of useful helper functions, used internally but not exported
 // with the rest of Cylon. 
-"use strict";
+
+// jshint strict:false
 
 var __slice = Array.prototype.slice;
 
@@ -201,4 +202,66 @@ extend(H, {
   arity: arity,
   partial: partial,
   partialRight: partialRight
+});
+
+function debounce(fn, delay, immediate) {
+  var timeout, timestamp, context, args, value;
+
+  var now = Date.now;
+
+  if (delay == null) {
+    delay = 100;
+  }
+
+  immediate = !!immediate;
+
+  function later() {
+    var last = now() - timestamp;
+
+    if (last > 0 && last < delay) {
+      timeout = setTimeout(later, delay - last);
+      return;
+    }
+
+    timeout = null;
+
+    if (!immediate) {
+      value = fn.apply(context, args);
+
+      if (!timeout) {
+        context = args = null;
+      }
+    }
+  }
+
+  function cancel() {
+    timeout = null;
+  }
+
+  function debounced() {
+    var shouldCallNow = !timeout && immediate;
+
+    context = this;
+    args = arguments;
+    timestamp = now();
+
+    if (!timeout) {
+      timeout = setTimeout(later, delay);
+    }
+
+    if (shouldCallNow) {
+      value = fn.apply(context, args);
+      context = args = null;
+    }
+
+    return value;
+  }
+
+  debounced.cancel = cancel;
+
+  return debounced;
+}
+
+extend(H, {
+  debounce: debounce
 });


### PR DESCRIPTION
Similar, but not quite, the same as throttling function invocations.

> **debounce (v)**: To remove the small ripple of current that forms when a mechanical switch is pushed in an electrical circuit and makes a series of short contacts.

The specs should paint a better picture of how this works and how it can be used.