### PR TITLE
Update license property to valid SPDX license

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/hybridgroup/cylon"
   },
 
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
 
   "hardware": {
     "*": false,


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/