### PR TITLE
Refactor Config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,8 +1,53 @@
 "use strict";
 
-module.exports = {
-  logging: {},
+var _ = require("./utils/helpers");
 
-  // are we in TDR test mode? Used to stub out adaptors/drivers.
-  testMode: false
+var config = module.exports = {},
+    callbacks = [];
+
+// default data
+config.logging = {};
+config.testMode = false;
+
+/**
+ * Updates the Config, and triggers handler callbacks
+ *
+ * @param {Object} data new configuration information to set
+ * @return {void}
+ */
+config.update = function update(data) {
+  var forbidden = ["update", "subscribe", "unsubscribe"];
+
+  Object.keys(data).forEach(function(key) {
+    if (~forbidden.indexOf(key)) { delete data[key]; }
+  });
+
+  if (!Object.keys(data).length) {
+    return;
+  }
+
+  _.extend(config, data);
+
+  callbacks.forEach(function(callback) { callback(data); });
+};
+
+/**
+ * Subscribes a function to be called whenever the config is updated
+ *
+ * @param {Function} callback function to be called with updated data
+ * @return {void}
+ */
+config.subscribe = function subscribe(callback) {
+  callbacks.push(callback);
+};
+
+/**
+ * Unsubscribes a callback from configuration changes
+ *
+ * @param {Function} callback function to unsubscribe from changes
+ * @return {void}
+ */
+config.unsubscribe = function unsubscribe(callback) {
+  var idx = callbacks.indexOf(callback);
+  if (idx >= 0) { callbacks.splice(idx, 1); }
 };

--- a/lib/cylon.js
+++ b/lib/cylon.js
@@ -120,18 +120,7 @@ Cylon.start = function start() {
 //
 // Returns the current config
 Cylon.config = function(opts) {
-  var loggingChanged = (
-    opts.logging && Config.logging !== _.extend(Config.logging, opts.logging)
-  );
-
-  if (_.isObject(opts)) {
-    Config = _.extend(Config, opts);
-  }
-
-  if (loggingChanged) {
-    Logger.setup();
-  }
-
+  if (_.isObject(opts)) { Config.update(opts); }
   return Config;
 };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,9 +9,7 @@ var BasicLogger = require("./logger/basic_logger"),
 
 var Logger = module.exports = {
   setup: function(opts) {
-    if (_.isObject(opts)) {
-      Config.logging = _.extend(Config.logging, opts);
-    }
+    if (_.isObject(opts)) { _.extend(Config.logging, opts); }
 
     var logger = Config.logging.logger,
         level = Config.logging.level || "info";
@@ -23,18 +21,19 @@ var Logger = module.exports = {
 
     logger = (logger == null) ? BasicLogger : logger;
 
-    this.logger = logger || NullLogger;
-    this.level = level;
+    Logger.logger = logger || NullLogger;
+    Logger.level = level;
 
-    return this;
+    return Logger;
   },
 
   toString: function() {
-    return this.logger.toString();
+    return Logger.logger.toString();
   }
 };
 
 Logger.setup();
+Config.subscribe(Logger.setup);
 
 levels.forEach(function(level) {
   Logger[level] = function() {

--- a/spec/lib/config.spec.js
+++ b/spec/lib/config.spec.js
@@ -1,0 +1,85 @@
+"use strict";
+
+var config = lib("config");
+
+describe("config", function() {
+  it("contains configuration options", function() {
+    expect(config.logging).to.be.an("object");
+    expect(config.testMode).to.be.eql(false);
+  });
+
+  describe("#update", function() {
+    var callback;
+
+    beforeEach(function() {
+      callback = spy();
+      config.subscribe(callback);
+    });
+
+    afterEach(function() {
+      config.unsubscribe(callback);
+      delete config.newValue;
+    });
+
+    it("updates the configuration", function() {
+      expect(config.newValue).to.be.eql(undefined);
+      config.update({ newValue: "value" });
+      expect(config.newValue).to.be.eql("value");
+    });
+
+    it("notifies subscribers of changes", function() {
+      var update = { newValue: "value" };
+      expect(callback).to.not.be.called;
+      config.update(update);
+      expect(callback).to.be.calledWith(update);
+    });
+
+    it("rejects changes that conflict with config functions", function() {
+      config.update({ update: null });
+      expect(config.update).to.be.a("function");
+    });
+
+    it("does nothing with empty changesets", function() {
+      config.update({});
+      expect(callback).to.not.be.called;
+    });
+  });
+
+  describe("#subscribe", function() {
+    var callback = spy();
+
+    afterEach(function() {
+      delete config.test;
+      config.unsubscribe(callback);
+    });
+
+    it("subscribes a callback to change updates", function() {
+      config.subscribe(callback);
+      config.update({ test: true });
+      expect(callback).to.be.calledWith({ test: true });
+    });
+  });
+
+  describe("#unsubscribe", function() {
+    var callback;
+
+    beforeEach(function() {
+      callback = spy();
+      config.subscribe(callback);
+    });
+
+    afterEach(function() {
+      delete config.test;
+    });
+
+    it("unsubscribes a callback from change updates", function() {
+      config.update({ test: true });
+      expect(callback).to.be.called;
+
+      config.unsubscribe(callback);
+
+      config.update({ test: false });
+      expect(callback).to.be.calledOnce;
+    });
+  });
+});

--- a/spec/lib/cylon.spec.js
+++ b/spec/lib/cylon.spec.js
@@ -111,15 +111,8 @@ describe("Cylon", function() {
 
   describe("#config", function() {
     beforeEach(function() {
-      for (var c in Config) {
-        delete Config[c];
-      }
-
-      stub(Logger, "setup");
-    });
-
-    afterEach(function() {
-      Logger.setup.restore();
+      delete Config.a;
+      delete Config.b;
     });
 
     it("sets config variables", function() {
@@ -145,14 +138,6 @@ describe("Cylon", function() {
       Cylon.config(["a", 1, "b", 2]);
       Cylon.config("hello world");
       expect(Config).to.be.eql(config);
-    });
-
-    it("updates the Logger setup if that changed", function() {
-      Cylon.config({ a: 1 });
-      expect(Logger.setup).to.not.be.called;
-
-      Cylon.config({ a: 1, logging: { logger: false } });
-      expect(Logger.setup).to.be.called;
     });
   });
 

--- a/spec/lib/logger.spec.js
+++ b/spec/lib/logger.spec.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var Logger = lib("logger"),
-    Config = lib("config");
+    Config = lib("config"),
+    NullLogger = lib("logger/null_logger");
 
 describe("Logger", function() {
   afterEach(function() {
@@ -145,5 +146,12 @@ describe("Logger", function() {
       expect(logger.debug).to.not.be.called;
       expect(logger.info).to.be.calledWith("info message");
     });
+  });
+
+  it("automatically updates if configuration changed", function() {
+    var custom = spy();
+    expect(Logger.logger).to.be.eql(NullLogger);
+    Config.update({ logging: { logger: custom } });
+    expect(Logger.logger).to.be.eql(custom);
   });
 });


### PR DESCRIPTION
Updates Cylon's internal config to act as a subscribable data store. Parts of the system can subscribe to updates, instead of being told what to do directly by another part of the system.