### PR TITLE
Consolidate Robot initialization

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -39,8 +39,6 @@ var Robot = module.exports = function Robot(opts) {
   }
 
   this.initRobot(opts);
-  this.initConnections(opts);
-  this.initDevices(opts);
 
   _.each(opts, function(opt, name) {
     if (this[name] !== undefined) {
@@ -148,20 +146,6 @@ Robot.prototype.initRobot = function(opts) {
   if (!this.work) {
     this.work = function() { this.log("debug", "No work yet."); };
   }
-};
-
-/**
- * Initializes a Robot's connections
- *
- * @param {Object} opts object passed to constructor
- * @return {Array} the Robot's connections
- */
-Robot.prototype.initConnections = function(opts) {
-  this.log("info", "Initializing connections.");
-
-  if (opts.connections == null) {
-    return this.connections;
-  }
 
   _.each(opts.connections, function(conn, key) {
     var name = _.isString(key) ? key : conn.name;
@@ -177,10 +161,13 @@ Robot.prototype.initConnections = function(opts) {
       delete conn.devices;
     }
 
-    this.connection(name, conn);
+    this.connection(name, _.extend({}, conn));
   }, this);
 
-  return this.connections;
+  _.each(opts.devices, function(device, key) {
+    var name = _.isString(key) ? key : device.name;
+    this.device(name, _.extend({}, device));
+  }, this);
 };
 
 /**
@@ -223,32 +210,6 @@ Robot.prototype.device = function(name, device) {
   this.devices[device.name] = initializer("driver", device);
 
   return this;
-};
-
-/**
- * Initializes a Robot's devices
- *
- * @param {Object} opts object passed to constructor
- * @return {Array} the Robot's devices
- */
-Robot.prototype.initDevices = function(opts) {
-  this.log("info", "Initializing devices.");
-
-  if (opts.devices == null) {
-    return this.devices;
-  }
-
-  // check that there are connections to use
-  if (!Object.keys(this.connections).length) {
-    throw new Error("No connections specified");
-  }
-
-  _.each(opts.devices, function(device, key) {
-    var name = _.isString(key) ? key : device.name;
-    this.device(name, device);
-  }, this);
-
-  return this.devices;
 };
 
 /**

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -84,6 +84,15 @@ checks.devicesWithoutConnection = function(opts) {
   }
 };
 
+checks.noConnections = function(opts) {
+  var connections = Object.keys(opts.connections || {}).length,
+      devices = Object.keys(opts.devices || {}).length;
+
+  if (devices && !connections) {
+    fatal(["No connections provided for devices"]);
+  }
+};
+
 module.exports.validate = function validate(opts) {
   opts = opts || {};
 

--- a/spec/lib/robot.spec.js
+++ b/spec/lib/robot.spec.js
@@ -70,7 +70,7 @@ describe("Robot", function() {
           });
         };
 
-        expect(fn).to.throw(Error, "No connections specified");
+        expect(fn).to.throw(Error);
       });
     });
 
@@ -264,27 +264,20 @@ describe("Robot", function() {
     });
   });
 
-  describe("initConnections", function() {
+  describe("initRobot", function() {
     var bot;
 
     beforeEach(function() {
       bot = new Robot();
     });
 
-    context("when not passed anything", function() {
-      it("does not modify the bot's connections", function() {
-        bot.initConnections({});
-        expect(bot.connections).to.be.eql({});
-      });
-    });
-
-    context("when passed an object containing connection details", function() {
+    context("when connection details are provided", function() {
       it("creates new connections with each of the ones provided", function() {
         var connections = {
           loopback: { adaptor: "loopback" }
         };
 
-        bot.initConnections({ connections: connections });
+        bot.initRobot({ connections: connections });
         expect(bot.connections.loopback).to.be.instanceOf(Adaptor);
       });
 
@@ -303,7 +296,7 @@ describe("Robot", function() {
             }
           };
 
-          bot.initConnections(opts);
+          bot.initRobot(opts);
         });
 
         it("adds the devices to opts.devices", function() {
@@ -315,6 +308,23 @@ describe("Robot", function() {
         it("removes the device details from optsconnections", function() {
           expect(opts.connections.devices).to.be.eql(undefined);
         });
+      });
+    });
+
+    context("when device details are provided", function() {
+      it("creates new devices with each of the ones provided", function() {
+        var opts = {
+          connections: {
+            loopback: { adaptor: "loopback" }
+          },
+
+          devices: {
+            ping: { driver: "ping" }
+          }
+        };
+
+        bot.initRobot(opts);
+        expect(bot.devices.ping).to.be.instanceOf(Driver);
       });
     });
   });
@@ -345,34 +355,7 @@ describe("Robot", function() {
     });
   });
 
-  describe("initDevices", function() {
-    var bot;
-
-    beforeEach(function() {
-      bot = new Robot({
-        connections: {
-          loopback: { adaptor: "loopback" }
-        }
-      });
-    });
-
-    context("when not passed anything", function() {
-      it("does not modify the bot's devices", function() {
-        bot.initDevices({});
-        expect(bot.devices).to.be.eql({});
-      });
-    });
-
-    context("when passed an object containing device details", function() {
-      it("creates new devices with each of the ones provided", function() {
-        var devices = {
-          ping: { driver: "ping" }
-        };
-
-        bot.initDevices({ devices: devices });
-        expect(bot.devices.ping).to.be.instanceOf(Driver);
-      });
-    });
+  describe("initRobot", function() {
   });
 
   describe("#start", function() {


### PR DESCRIPTION
Condenses the logic of `#initConnections` and `#initDevices` down into `#initRobot`. Additionally, extracts validation of connections being present out to the validator logic.