### PR TITLE
Correcting the test Adaptor and Driver

### DIFF
--- a/lib/test/test-adaptor.js
+++ b/lib/test/test-adaptor.js
@@ -9,5 +9,14 @@ var TestAdaptor = module.exports = function TestAdaptor() {
 
 Utils.subclass(TestAdaptor, Adaptor);
 
+
+TestAdaptor.prototype.connect = function(callback) {
+  callback();
+};
+
+TestAdaptor.prototype.disconnect = function(callback) {
+  callback();
+};
+
 TestAdaptor.adaptors = ["test"];
 TestAdaptor.adaptor = function(opts) { return new TestAdaptor(opts); };

--- a/lib/test/test-driver.js
+++ b/lib/test/test-driver.js
@@ -9,5 +9,13 @@ var TestDriver = module.exports = function TestDriver() {
 
 Utils.subclass(TestDriver, Driver);
 
+TestDriver.prototype.start = function(callback) {
+  callback();
+};
+
+TestDriver.prototype.halt = function(callback) {
+  callback();
+};
+
 TestDriver.drivers = ["test"];
 TestDriver.driver = function(opts) { return new TestDriver(opts); };


### PR DESCRIPTION
Right now the test Adaptor and Driver can't be used because they don't implement their superclass required methods (connect, disconnect, start and halt).